### PR TITLE
Delete code changer for ssl-logtools/logplayer

### DIFF
--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -175,55 +175,7 @@ function build_ssl_tools() {
 
     # ssl-logtools
     cd ../ssl-logtools && mkdir build && cd "$_"
-
-    selector_fix_logplayer
     cmake .. && make || echo "Failed to build ssl-logtools"
-}
-
-function selector_fix_logplayer() {
-    echo ""
-    echo "[Jan 7 ,2018]Codes of LogPlayer has some probrems."
-    echo "see : https://github.com/RoboCup-SSL/ssl-logtools/pull/1"
-    echo -n "Do you want to fix them automatically?[Y/n]:"
-    read -r -t 60 is_fix
-    case "$is_fix" in
-        "" | "y" | "Y" | "yes" | "YES" | "Yes" )
-            fix_code_logplayer -SSL_DIR || echo "ERROR:failed to fix codes.";;
-        * )
-            echo "Did not fix codes.";;
-    esac
-}
-
-function fix_code_logplayer() {
-    cd ../src/logplayer || exit
-    echo "fix the code : logplayer/player.cpp"
-    cp player.cpp  player_org.cpp
-    sed -i '87a\ \ \ \ return true;' player.cpp && echo "Done"
-
-    echo "fix the code : logplayer/mainwindow.cpp"
-    cp mainwindow.cpp  mainwindow_org.cpp
-    sed -i -e '31a\ \ \ \ connect(m_ui->horizontalSlider, SIGNAL(sliderReleased()),SLOT(userSliderChange()));/*' mainwindow.cpp && echo -n "."
-    sed -i -e '33a\ \ \ \ */' -e '$ a \ '  mainwindow.cpp && echo -n "."
-    sed -i -e '$ a void MainWindow::userSliderChange()' mainwindow.cpp && echo -n "."
-    sed -i -e '$ a {' mainwindow.cpp && echo -n "."
-    sed -i -e '$ a \ \ \ \ int\ value\ =\ m_ui->horizontalSlider->value();' mainwindow.cpp && echo -n "."
-    sed -i -e '$ a \ \ \ \ seekFrame(value);' -e  '$a }' mainwindow.cpp && echo "Done."
-
-    echo "fix the code : logplayer/mainwindow.h"
-    cp mainwindow.h mainwindow_org.h
-    sed -i -e '38a \ \ \ \ void\ userSliderChange();' mainwindow.h && echo "Done."
-    echo ""
-    echo "If there're any problem when you use logplayer, try them to re-build with original code:"
-    echo ">$ cd /path/to/ssl-logtools // go to directory of ssl-logtools"
-    echo ">$ rm src/logplayer/player.cpp src/logplayer/mainwindow.cpp src/logplayer/mainwindow.h"
-    echo ">$ mv src/logplayer/player_org.cpp src/logplayer/player.cpp"
-    echo ">$ mv src/logplayer/mainwindow_org.cpp src/logplayer/mainwindow.cpp"
-    echo ">$ mv src/logplayer/mainwindow_org.h src/logplayer/mainwindow.h"
-    echo ">$ sudo rm -r build"
-    echo ">$ mkdir build && cd $_"
-    echo ">$ cmake .. && make"
-    echo ""
-    cd ../../build
 }
 
 function install_dev_tools() {

--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -82,6 +82,7 @@ function install_libraries() {
             # install most of required packages for Robocup-SSL official tools (without Autoref)
             sudo dnf -y install git boost-devel clang cmake eigen3 libtool libyaml-devel make ninja-build protobuf-devel automake gcc gcc-c++ kernel-devel qt-devel mesa-libGL-devel mesa-libGLU-devel protobuf-compiler ode ode-devel gtkmm24-devel libjpeg libpng v4l-utils libdc1394 libdc1394-devel zlib || echo "Failed to instlal some packages."
 
+            # in fedora, you have to build ODE-0.13 from source. new version of ODE will cause freeze of grSim
             wget https://jaist.dl.sourceforge.net/project/opende/ODE/0.13/ode-0.13.tar.bz2 || echo "Failed to download ode-0.13.tar.bz2. Check your internet connection."
             tar xf ode-0.13.tar.bz2 && rm ode-0.13.tar.bz2
             cd ode-0.13
@@ -247,7 +248,6 @@ function install_dev_tools() {
                     ;;
                 "arch" )
                     sudo pacman -Sy htop wireshark-cli strace ltrace vim
-                    # echo "Not supported now. Wait for update.";exit
                     ;;
                 * )
                     echo "Not supported.";


### PR DESCRIPTION
Pull request 5 of ssl-logtools has been merged .
So we don't need these function - selector_fix_logplayer() and fix_code_logplayer() .