### PR TITLE
build logtools and vision with Qt5

### DIFF
--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -233,12 +233,14 @@ function build_ssl_tools() {
     cmake .. && make || echo "Failed to build grSim"
 
     # ssl-vision/graphicalClient
-    cd ../../ssl-vision
+    cd ../../ssl-vision && mkdir build && cd "$_"
+    cmake .. -DUSE_QT5
     make || echo "Failed to build ssl-vision"
 
     # ssl-logtools
     cd ../ssl-logtools && mkdir build && cd "$_"
-    cmake .. && make || echo "Failed to build ssl-logtools"
+    cmake .. -DUSE_QT5
+    make || echo "Failed to build ssl-logtools"
 
     cd ../../ssl-autorefs
     bash buildAll.sh

--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -213,11 +213,11 @@ function build_ssl_tools() {
             # nothing typed
             if test -z "$SSL_DIR"
             then
-                mkdir -p ${ssl_dir_default} && cd "$_" && break
-            else
-                echo "install for $SSL_DIR."
-                mkdir -p "$SSL_DIR" && cd "$_" && break
+                SSL_DIR=${ssl_dir_default};
             fi
+            echo "install for $SSL_DIR."
+            mkdir -p "$SSL_DIR" && cd "$_" && break
+            
         ;;
     esac
     done
@@ -233,20 +233,20 @@ function build_ssl_tools() {
     cmake .. && make || echo "Failed to build grSim"
 
     # ssl-vision/graphicalClient
-    cd ../../ssl-vision && mkdir build && cd "$_"
+    cd ${SSL_DIR}/ssl-vision && mkdir build && cd "$_"
     cmake .. -DUSE_QT5=true
     make || echo "Failed to build ssl-vision"
 
     # ssl-logtools
-    cd ../ssl-logtools && mkdir build && cd "$_"
+    cd ${SSL_DIR}/ssl-logtools && mkdir build && cd "$_"
     cmake .. -DUSE_QT5=true
     make || echo "Failed to build ssl-logtools"
 
-    cd ../../ssl-autorefs
+    cd ${SSL_DIR}/ssl-autorefs
     bash buildAll.sh
 
     # new ssl client (ssl-game-controller and so on)
-    cd ../
+    cd ${SSL_DIR}
     mkdir games && cd $_
     wget `curl -s https://api.github.com/repos/robocup-ssl/ssl-game-controller/releases | jq -r '.[0].assets[] | select(.name | test("linux_amd64")) | .browser_download_url'`
     wget `curl -s https://api.github.com/repos/robocup-ssl/ssl-vision-client/releases | jq -r '.[0].assets[] | select(.name | test("linux_amd64")) | .browser_download_url'`

--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -234,12 +234,12 @@ function build_ssl_tools() {
 
     # ssl-vision/graphicalClient
     cd ../../ssl-vision && mkdir build && cd "$_"
-    cmake .. -DUSE_QT5
+    cmake .. -DUSE_QT5=true
     make || echo "Failed to build ssl-vision"
 
     # ssl-logtools
     cd ../ssl-logtools && mkdir build && cd "$_"
-    cmake .. -DUSE_QT5
+    cmake .. -DUSE_QT5=true
     make || echo "Failed to build ssl-logtools"
 
     cd ../../ssl-autorefs


### PR DESCRIPTION
On Arch Linux, Qt4 is already "Legacy" and not exist on official repo.
grSim already supports build with Qt5 (updating vartypes).
logtools and ssl-vision have made a update to support Qt5,
so now I can build with Qt5.

see #25

Test 
- [x] Fedora 29, 30
- [x] Ubuntu 16.04, 18.04
- [x] Arch Linux