### PR TITLE
update method to create temporal directory

### DIFF
--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -134,8 +134,7 @@ function install_libraries() {
     local apt_pkg_ssl_autorefs="patch"
     local apt_pkg_opencv="build-essential libgtk2.0dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev libpng-dev libtiff-dev"
 
-    path_tmp="$(mktemp)"
-    mkdir -p "$path_tmp"
+    path_tmp="$(mktemp -d)"
     cd "$path_tmp"
 
     # trap : remove temporal directory

--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -138,6 +138,9 @@ function install_libraries() {
     mkdir -p "$path_tmp"
     cd "$path_tmp"
 
+    # trap : remove temporal directory
+    trap 'rm -rf ${path_tmp}; echo "Deleted temporal directory ${path_tmp}"; error_end 1 "proces killed"' 2 
+
     DISTRIBU=$(get_os_distribution)
     echo "You're using $DISTRIBU"
     case "$DISTRIBU" in

--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -112,7 +112,7 @@ function install_opencv() {
 
 function install_libraries() {
     # temporary folder to build ODE, vartypes
-    local path_tmp=/home/${SUDO_USER}/Documents/sslinst_tmp/
+    local path_tmp
 
     # packages required to run this script
     local dnf_pkg_script="curl git cmake make gcc gcc-c++ jq xdg-utils"
@@ -134,10 +134,8 @@ function install_libraries() {
     local apt_pkg_ssl_autorefs="patch"
     local apt_pkg_opencv="build-essential libgtk2.0dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev libpng-dev libtiff-dev"
 
-    if [ ! -e "$path_tmp" ]
-    then
-        mkdir -p "$path_tmp"
-    fi
+    path_tmp="$(mktemp)"
+    mkdir -p "$path_tmp"
     cd "$path_tmp"
 
     DISTRIBU=$(get_os_distribution)


### PR DESCRIPTION
closes #34  

## overview
through this PR, method to create temporal directory will be updated.

```sh
# old
path_tmp="/home/${SUDO_USER}/Documents/sslinst_tmp/"
# this line will be run as root. It will cause permission problem if ~/Documents does not exist
# (owner of /home/${SUDO_USER}/Documents will be root)
mkdir -p path_tmp
```
This causes problem when ~/Documents does not exist (e.g. xfce does not provide any directory in ~/ excluding Desktop)

```sh
# new : will be created on /tmp/
path_tmp="$(mktemp -d)"
```

Much simple. And I don't have to care about permission of temporal directory. 


## test
- [x] Arch Linux
  - [x] with minimal xfce desktop environment
  - [x] with minimal GNOME3 desktop environment
- [x] Fedora 29
  - [x] with minimal xfce desktop environment
  - [x] with minimal GNOME3 desktop environment
- [x] Fedora 30
- [x] Ubuntu 16.04LTS
- [x] Ubuntu 18.04LTS
