### PR TITLE
delete option for ssl-vision USE_QT5 (already default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Just for beginner.
 
 Only tested on
 
-* Fedora 27 or later
-* Ubuntu 16.04 or later
+* Fedora 30 or later
+* Ubuntu 18.04 or later (to support QT5 by default)
 * Arch Linux
 
 ## Running

--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -243,7 +243,7 @@ function build_ssl_tools() {
 
     # ssl-vision/graphicalClient
     cd ${SSL_DIR}/ssl-vision && mkdir build && cd "$_"
-    cmake .. -DUSE_QT5=true || error_end $? "cmake configuration for ssl-vision failed"
+    cmake .. || error_end $? "cmake configuration for ssl-vision failed"
     make || error_end $? "Failed to build ssl-vision"
 
     # ssl-logtools


### PR DESCRIPTION
closes #38