### PR TITLE
Fedora 30 drop out

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Just for beginner.
 [ssl-vision-client](https://github.com/RoboCup-SSL/ssl-vision-client)  
 [ssl-autorefs](https://github.com/RoboCup-SSL/ssl-autorefs)
 
-Only tested on
+Supported OS:
 
-* Fedora 30 or later
+* Fedora 31 or later
 * Ubuntu 18.04, 19.04, 20.04 (to support QT5 by default)
 * Arch Linux
 

--- a/ssl_autosetup.sh
+++ b/ssl_autosetup.sh
@@ -116,7 +116,7 @@ function install_libraries() {
 
     # packages required to run this script
     local dnf_pkg_script="curl git cmake make gcc gcc-c++ jq xdg-utils"
-    local dnf_pkg_grsim="mesa-libGL-devel mesa-libGLU-devel qt-devel protobuf-compiler protobuf-devel boost-devel"
+    local dnf_pkg_grsim="mesa-libGL-devel mesa-libGLU-devel qt-devel protobuf-compiler protobuf-devel boost-devel ode-double ode-devel"
     local dnf_pkg_ssl_vision="qt-devel eigen3 libjpeg libpng v4l-utils libdc1394 libdc1394-devel protobuf-compiler protobuf-devel opencv-devel freeglut-devel zlib"
     local dnf_pkg_ssl_logtools="protobuf-compiler zlib-devel boost-program-options"
     local dnf_pkg_ssl_autoref="patch"
@@ -151,9 +151,6 @@ function install_libraries() {
             dnf -y install ${dnf_pkg_script} ${dnf_pkg_grsim} ${dnf_pkg_ssl_vision} ${dnf_pkg_ssl_logtools} ${dnf_pkg_ssl_autoref} || error_end $? "Failed to instlal some packages."
             
             dnf -y install firefox google-noto-sans-cjk-jp-fonts
-
-            # in fedora, you have to build ODE-0.13 from source. new version of ODE will cause freeze of grSim
-            install_ode_013
             ;;
         "ubuntu" )
             apt update -qq -y || error_end $? "Failed to update. Check your internet connection." 


### PR DESCRIPTION
End of life for fedora 30 has come.
after fedora 31, we can use ode-double : ode that enables double-precision
so we can use this instead of building from source

Partially solves #37